### PR TITLE
fix(group-messages): prevent image upload crash and render sender’s message immediately

### DIFF
--- a/backend/src/controllers/groupMessage.controller.js
+++ b/backend/src/controllers/groupMessage.controller.js
@@ -1,6 +1,7 @@
 import Message from "../models/message.model.js";
 import Group from "../models/group.model.js";
 import { getReceiverSocketId, io } from "../lib/socket.js";
+import cloudinary from "../lib/cloudinary.js";
 
 export const sendGroupMessage = async (req, res) => {
   try {
@@ -13,8 +14,16 @@ export const sendGroupMessage = async (req, res) => {
 
     let imageUrl = null;
     if (image) {
-      const uploadResponse = await cloudinary.uploader.upload(image);
-      imageUrl = uploadResponse.secure_url;
+      // If image is an external URL (e.g., GIPHY), store as-is; otherwise upload base64 to Cloudinary
+      if (
+        typeof image === "string" &&
+        (image.startsWith("http://") || image.startsWith("https://"))
+      ) {
+        imageUrl = image;
+      } else {
+        const uploadResponse = await cloudinary.uploader.upload(image);
+        imageUrl = uploadResponse.secure_url;
+      }
     }
 
     const newMessage = await Message.create({

--- a/frontend/src/store/useChatStore.js
+++ b/frontend/src/store/useChatStore.js
@@ -307,6 +307,8 @@ export const useChatStore = create((set, get) => ({
         `/group-messages/send/${groupId}`,
         messageData
       );
+      // Immediately reflect the sent message for the sender to avoid waiting for socket echo
+      set({ groupMessages: [...get().groupMessages, res.data] });
     } catch (error) {
       console.error("Error sending group message:", error);
       toast.error(


### PR DESCRIPTION
### Summary
This PR fixes two related group messaging issues:

#### Backend crash on group image messages due to missing Cloudinary import.
#### Sender’s group message not appearing immediately after POST.
Closes: #48 

### Changes
[groupMessage.controller.js]
Added [import cloudinary from "../lib/cloudinary.js";]
Matched 1:1 message behavior:
If [image] is an http/https URL (e.g., GIPHY), store URL directly (no Cloudinary upload).
If [image] is base64, upload to Cloudinary and store [secure_url]
[useChatStore.js]

After successful POST /group-messages/send/:groupId, append [res.data] to [groupMessages] so the sender sees the message immediately.
Socket listener remains to handle messages from other members; sender is still ignored to avoid duplicates.

#### Why
Fixes “ReferenceError: cloudinary is not defined” on group image sends.
Improves UX by showing the sender’s message without needing a refresh/re-fetch.

### How to test
Group text send: message appears instantly for sender and via socket for others.
Group GIF send (GIPHY URL): saves URL directly; no server crash.
Group image upload (base64): uploads to Cloudinary and renders; no crash.
Verify 1:1 messaging (text/image) still behaves as before.

Ensure backend .env has Cloudinary credentials and [FRONTEND_URL]
Start backend and frontend; open two users and test a group chat.
Risk/Regression
Sender duplicates: prevented by ignoring sender in the socket listener and appending only on POST success.
No API shape changes; only controller logic and client store update.

### This will be an official contribution for Hacktoberfest 25'
