### PR TITLE
Add leave group option for the user

### DIFF
--- a/backend/src/controllers/group.controller.js
+++ b/backend/src/controllers/group.controller.js
@@ -113,3 +113,37 @@ export const getUserGroups = async (req, res) => {
     res.status(500).json({ message: "Internal server error" });
   }
 };
+
+export const leaveGroup = async (req, res) => {
+  try {
+    const { user } = req;
+    const { groupId } = req.params;
+
+    const group = await Group.findById(groupId);
+    if (!group.members.includes(user._id)) {
+      return res
+        .status(401)
+        .json({ message: "You are not a member of this group" });
+    }
+
+    if (group.admin.toString() === user._id.toString()) {
+      return res
+        .status(400)
+        .json({ message: "Admin cannot leave the group directly" });
+    }
+
+    group.members = group.members.filter(
+      (memberId) => memberId.toString() !== user._id.toString()
+    );
+
+    await group.save();
+    res.json({
+      success: true,
+      message: "Left group successfully",
+      members: group.members,
+    });
+  } catch (error) {
+    console.error("❌ Error leaving group:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/backend/src/controllers/groupMessage.controller.js
+++ b/backend/src/controllers/groupMessage.controller.js
@@ -11,6 +11,8 @@ export const sendGroupMessage = async (req, res) => {
 
     const group = await Group.findById(groupId);
     if (!group) return res.status(404).json({ message: "Group not found" });
+    if (!group.members.includes(senderId))
+      return res.status(401).json({ message: "You are not in this group" });
 
     let imageUrl = null;
     if (image) {
@@ -58,6 +60,12 @@ export const sendGroupMessage = async (req, res) => {
 export const getGroupMessages = async (req, res) => {
   try {
     const { groupId } = req.params;
+    const senderId = req.user._id;
+
+    const group = await Group.findById(groupId);
+    if (!group) return res.status(404).json({ message: "Group not found" });
+    if (!group.members.includes(senderId))
+      return res.status(401).json({ message: "You are not in this group" });
 
     const messages = await Message.find({ groupId })
       .populate("senderId", "fullName profilePic")

--- a/backend/src/routes/group.route.js
+++ b/backend/src/routes/group.route.js
@@ -1,11 +1,12 @@
 import express from "express";
 import {protectRoute} from "../middleware/auth.middleware.js"
-import {getUserGroups, createGroup, addMembers, removeMembers} from "../controllers/group.controller.js"
+import {getUserGroups, createGroup, addMembers, removeMembers, leaveGroup} from "../controllers/group.controller.js"
 
 const router = express.Router();
 router.post("/create", protectRoute, createGroup);
 router.post("/:groupId/add-members", protectRoute, addMembers);
 router.post("/:groupId/remove-members", protectRoute, removeMembers);
 router.get("/my-groups", protectRoute, getUserGroups);
+router.post("/:groupId/leave-group", protectRoute, leaveGroup);
 
 export default router;

--- a/frontend/src/components/GroupChatContainer.jsx
+++ b/frontend/src/components/GroupChatContainer.jsx
@@ -18,6 +18,7 @@ const GroupChatContainer = () => {
     unsubscribeFromGroupMessages,
     addGroupMembers,
     removeGroupMembers,
+    leaveGroup,
   } = useChatStore();
 
   const { authUser } = useAuthStore();
@@ -89,7 +90,7 @@ const GroupChatContainer = () => {
     <div className="flex-1 flex flex-col overflow-auto">
       <ChatHeader isGroup groupName={selectedGroup?.name} />
 
-      {isAdmin && (
+      {isAdmin ? (
         <div className="flex items-center justify-end gap-2 mt-3">
           <button
             onClick={() => setShowManageMembers(true)}
@@ -98,6 +99,13 @@ const GroupChatContainer = () => {
             Manage Members
           </button>
         </div>
+      ) : (
+        <button
+          onClick={() => leaveGroup(selectedGroup._id)}
+          className="px-3 py-1.5 rounded-md btn btn-outline border text-red-400 bg-base-100 border-gray-300 hover:bg-base-300 text-sm font-medium"
+        >
+          Leave Group
+        </button>
       )}
 
       {showManageMembers && (


### PR DESCRIPTION
Closes #45

This PR adds the ability for users to **leave a group chat** in both the backend and frontend.  
Previously, users could only add or remove members (admin actions).  
Now, any non-admin member can voluntarily leave a group.

---

## 🔧 Backend Changes

### **Files Modified**
- **`backend/src/controllers/group.controller.js`**
  - Added new controller: `leaveGroup`
    - Validates that the group exists.
    - Ensures the user is a current member.
    - Prevents group admin from leaving directly.
    - Removes the user from the `members` array and saves the updated group.
  - Returns updated member list and success message.

- **`backend/src/routes/group.route.js`**
  - Added new route:
    ```js
    POST /groups/:groupId/leave-group
    ```

- **`backend/src/controllers/groupMessage.controller.js`**
  - Added membership validation to:
    - `sendGroupMessage`
    - `getGroupMessages`
  - Ensures only valid group members can send or retrieve messages.

---

## 💻 Frontend Changes

### **Files Modified**
- **`frontend/src/store/useChatStore.js`**
  - Added new store action `leaveGroup(groupId)`:
    - Calls the `POST /groups/:groupId/leave-group` API.
    - Updates state by removing the user from the group’s members.
    - Displays success or error toasts based on the response.

- **`frontend/src/components/GroupChatContainer.jsx`**
  - Added a **“Leave Group”** button for non-admin members.
  - Admins continue to see the “Manage Members” button.
  - Integrated the `leaveGroup` action from the chat store.