### PR TITLE
Add option for adding and removing admin from the group

### DIFF
--- a/backend/src/models/group.model.js
+++ b/backend/src/models/group.model.js
@@ -14,10 +14,12 @@ const groupSchema = new mongoose.Schema(
       required: true,
     },
 
-    admin: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "User",
-    },
+    admin: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "User",
+      },
+    ],
 
     members: [
       {
@@ -37,9 +39,10 @@ const groupSchema = new mongoose.Schema(
 );
 
 groupSchema.pre("save", function (next) {
-   if (!this.admin) {
-    this.admin = this.createdBy;
+  if (!this.admin || this.admin.length === 0) {
+    this.admin = [this.createdBy];
   }
+
   if (!this.members.includes(this.createdBy)) {
     this.members.push(this.createdBy);
   }

--- a/backend/src/routes/group.route.js
+++ b/backend/src/routes/group.route.js
@@ -1,6 +1,6 @@
 import express from "express";
 import {protectRoute} from "../middleware/auth.middleware.js"
-import {getUserGroups, createGroup, addMembers, removeMembers, leaveGroup} from "../controllers/group.controller.js"
+import {getUserGroups, createGroup, addMembers, removeMembers, leaveGroup, addAdmin, removeAdmin} from "../controllers/group.controller.js"
 
 const router = express.Router();
 router.post("/create", protectRoute, createGroup);
@@ -8,5 +8,7 @@ router.post("/:groupId/add-members", protectRoute, addMembers);
 router.post("/:groupId/remove-members", protectRoute, removeMembers);
 router.get("/my-groups", protectRoute, getUserGroups);
 router.post("/:groupId/leave-group", protectRoute, leaveGroup);
+router.post("/:groupId/add-admin", protectRoute, addAdmin);
+router.post("/:groupId/remove-admin", protectRoute, removeAdmin);
 
 export default router;

--- a/frontend/src/store/useChatStore.js
+++ b/frontend/src/store/useChatStore.js
@@ -425,4 +425,50 @@ export const useChatStore = create((set, get) => ({
       toast.error(error.response?.data?.message || "Failed to leave group");
     }
   },
+
+  addGroupAdmin: async (groupId, userIds) => {
+    try {
+      const res = await axiosInstance.post(
+        `/groups/${groupId}/add-admin`,
+        { userIds },
+        { headers: { "Content-Type": "application/json" } }
+      );
+
+      toast.success(res.data.message || "Admin added successfully!");
+
+      set((state) => ({
+        groups: state.groups.map((group) =>
+          group._id === groupId ? { ...group, admin: res.data.admin } : group
+        ),
+      }));
+
+      return res.data;
+    } catch (error) {
+      console.error("Error adding admins:", error);
+      toast.error(error.response?.data?.message || "Failed to add admins");
+    }
+  },
+
+  removeGroupAdmin: async (groupId, userIds) => {
+    try {
+      const res = await axiosInstance.post(
+        `/groups/${groupId}/remove-admin`,
+        { userIds },
+        { headers: { "Content-Type": "application/json" } }
+      );
+
+      toast.success(res.data.message || "Admin removed successfully!");
+
+      set((state) => ({
+        groups: state.groups.map((group) =>
+          group._id === groupId ? { ...group, admin: res.data.admin } : group
+        ),
+      }));
+
+      return res.data;
+    } catch (error) {
+      console.error("Error removing admins:", error);
+      toast.error(error.response?.data?.message || "Failed to remove admins");
+    }
+  },
 }));


### PR DESCRIPTION
Closes #46 

This PR introduces the ability to **promote members to admins and demote admins back to members** in group chats. Key updates include:

- Backend now supports multiple admins per group.
- API endpoints:
  - `POST /groups/:groupId/add-admin` – Promote member(s) to admin.
  - `POST /groups/:groupId/remove-admin` – Demote admin(s) to member.
- Frontend UI updated in `GroupChatContainer`:
  - Added **Manage Admins** tab in Manage Members modal.
  - Members can be promoted/demoted with **Promote/Demote buttons**.
- Zustand store (`useChatStore`) updated with `addGroupAdmin` and `removeGroupAdmin` functions.
- MongoDB `Group` model updated to store **admins as an array**, not a single value.

#### Backend Changes
- `group.controller.js`:
  - Updated `admin` checks to handle array of admins.
  - Added `addAdmin` and `removeAdmin` controllers.
  - Modified `addMembers`, `removeMembers`, and `leaveGroup` to support multiple admins.
- `group.model.js`:
  - `admin` field changed to array.
  - `pre('save')` hook updated to initialize `admin` array with `createdBy`.
- `group.route.js`:
  - Added routes for `add-admin` and `remove-admin`.

#### Frontend Changes
- `GroupChatContainer.jsx`:
  - Added `adminIds` state to track current admins.
  - Added **Promote/Demote functionality** in Manage Members modal.
  - Updated `isAdmin` check to support multiple admins.
- `useChatStore.js`:
  - Added `addGroupAdmin` and `removeGroupAdmin` API methods.
  - State updates to reflect changes in `admin` array.