### PR TITLE
fix(ui): correct group name text color in sidebar for Light theme

### DIFF
--- a/frontend/src/components/groupsSidebarIcon.jsx
+++ b/frontend/src/components/groupsSidebarIcon.jsx
@@ -13,9 +13,7 @@ const GroupSidebarIcon = ({ group, isActive, onClick }) => {
       >
         {firstLetter}
       </div>
-      <span className="text-sm font-medium text-white truncate">
-        {group.name}
-      </span>
+      <span className="text-sm font-medium truncate">{group.name}</span>
     </div>
   );
 };


### PR DESCRIPTION
This PR fixes an issue where the group name text in the sidebar appeared white while using the Light theme, making it unreadable.

Issue Fixed

Fixes #67

<img width="1711" height="956" alt="image" src="https://github.com/user-attachments/assets/2772814f-7d93-4779-bbaf-a9521a255457" />
