### PR TITLE
add group description and see which member are in that group 

### DIFF
--- a/backend/src/controllers/group.controller.js
+++ b/backend/src/controllers/group.controller.js
@@ -220,3 +220,35 @@ export const removeAdmin = async (req, res) => {
     res.status(500).json({ message: "Internal server error" });
   }
 };
+
+export const updateGroupDescription = async (req, res) => {
+  try {
+    const { description } = req.body;
+    const { groupId } = req.params;
+
+    const group = await Group.findById(groupId);
+    if (!group) {
+      return res.status(404).json({ message: "Group not found" });
+    }
+
+    const isAdmin = group.admin.some(
+      (id) => id.toString() === req.user._id.toString()
+    );
+
+    if (!isAdmin) {
+      return res.status(403).json({ message: "Only admins can edit description" });
+    }
+
+    group.description = description;
+    await group.save();
+
+    res.json({
+      success: true,
+      message: "Description updated successfully",
+      group,
+    });
+  } catch (err) {
+    console.error("Error updating description:", err);
+    res.status(500).json({ message: "Server error" });
+  }
+};

--- a/backend/src/models/group.model.js
+++ b/backend/src/models/group.model.js
@@ -8,6 +8,12 @@ const groupSchema = new mongoose.Schema(
       trim: true,
     },
 
+    description: {
+      type: String,
+      default: "",
+      trim: true,
+    },
+
     createdBy: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "User",
@@ -46,6 +52,7 @@ groupSchema.pre("save", function (next) {
   if (!this.members.includes(this.createdBy)) {
     this.members.push(this.createdBy);
   }
+
   next();
 });
 

--- a/backend/src/routes/group.route.js
+++ b/backend/src/routes/group.route.js
@@ -1,6 +1,6 @@
 import express from "express";
 import {protectRoute} from "../middleware/auth.middleware.js"
-import {getUserGroups, createGroup, addMembers, removeMembers, leaveGroup, addAdmin, removeAdmin} from "../controllers/group.controller.js"
+import {getUserGroups, createGroup, addMembers, removeMembers, leaveGroup, addAdmin, removeAdmin, updateGroupDescription,} from "../controllers/group.controller.js"
 
 const router = express.Router();
 router.post("/create", protectRoute, createGroup);
@@ -10,5 +10,6 @@ router.get("/my-groups", protectRoute, getUserGroups);
 router.post("/:groupId/leave-group", protectRoute, leaveGroup);
 router.post("/:groupId/add-admin", protectRoute, addAdmin);
 router.post("/:groupId/remove-admin", protectRoute, removeAdmin);
+router.put("/:groupId/description", protectRoute, updateGroupDescription);
 
 export default router;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,7 +74,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -891,7 +890,6 @@
       "version": "19.2.2",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -927,7 +925,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1030,7 +1027,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -1166,8 +1162,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/daisyui": {
       "version": "5.3.7",
@@ -1786,7 +1781,6 @@
       "version": "9.38.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2795,7 +2789,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2853,7 +2846,6 @@
     "node_modules/react": {
       "version": "19.2.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2861,7 +2853,6 @@
     "node_modules/react-dom": {
       "version": "19.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3509,7 +3500,6 @@
       "version": "6.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/src/components/ChatHeader.jsx
+++ b/frontend/src/components/ChatHeader.jsx
@@ -3,6 +3,7 @@ import { useAuthStore } from "../store/useAuthStore";
 import { useChatStore } from "../store/useChatStore";
 import EncryptionToggle from "./EncryptionToggle";
 import PinButton from "./PinButton";
+import GroupInfoPopup from  "../components/GroupInfoPopup.jsx";
 import { useEffect, useState } from "react";
 
 const ChatHeader = ({ isGroup = false, showSidebar, setShowSidebar }) => {
@@ -16,6 +17,7 @@ const ChatHeader = ({ isGroup = false, showSidebar, setShowSidebar }) => {
 
   const { onlineUsers, typingUsers } = useAuthStore();
   const [isTyping, setIsTyping] = useState(false);
+  const [showGroupInfo, setShowGroupInfo] = useState(false);
 
   useEffect(() => {
     setIsTyping(typingUsers[selectedUser?._id] || false);
@@ -25,6 +27,7 @@ const ChatHeader = ({ isGroup = false, showSidebar, setShowSidebar }) => {
   if (!chatTarget) return null;
 
   return (
+    <>
     <div className="p-2.5 border-b border-base-300">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -55,7 +58,10 @@ const ChatHeader = ({ isGroup = false, showSidebar, setShowSidebar }) => {
 
           {/* User info */}
           <div>
-            <h3 className="font-medium">
+            <h3
+              className="font-medium cursor-pointer hover:underline"
+              onClick={() => isGroup && setShowGroupInfo(true)}
+            >
               {isGroup
                 ? chatTarget.name
                 : chatTarget.fullName || chatTarget.name || ""}
@@ -93,9 +99,17 @@ const ChatHeader = ({ isGroup = false, showSidebar, setShowSidebar }) => {
           >
             <X />
           </button>
+
+          {showGroupInfo && (
+              <GroupInfoPopup
+                group={selectedGroup}
+                onClose={() => setShowGroupInfo(false)}
+              />
+            )}
         </div>
       </div>
     </div>
+    </>
   );
 };
 

--- a/frontend/src/components/GroupInfoPopup.jsx.jsx
+++ b/frontend/src/components/GroupInfoPopup.jsx.jsx
@@ -1,0 +1,101 @@
+import { X, Users } from "lucide-react";
+import { useState } from "react";
+import { useChatStore } from "../store/useChatStore";
+import { axiosInstance } from "../lib/axios";
+import toast from "../lib/toast";
+
+const GroupInfoPopup = ({ group, onClose }) => {
+  const [description, setDescription] = useState(group.description || "");
+  const [isEditing, setIsEditing] = useState(false);
+  const { getGroups } = useChatStore();
+
+  const handleSave = async () => {
+    try {
+      await axiosInstance.put(`/groups/${group._id}/description`, { description });
+      toast.success("Description updated");
+      await getGroups(); // refresh group data
+      setIsEditing(false);
+    } catch (error) {
+      toast.error(error.response?.data?.message || "Failed to update description");
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex justify-center items-center z-50">
+      <div className="bg-base-100 rounded-2xl shadow-lg p-5 w-[95%] max-w-md relative">
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 text-gray-500 hover:text-white"
+        >
+          <X />
+        </button>
+
+        <div className="text-center mb-4">
+          <h2 className="text-lg font-semibold">{group.name}</h2>
+          <p className="text-sm text-gray-400">
+            {group.members?.length || 0} members
+          </p>
+        </div>
+
+        {/* Description */}
+        <div className="mb-4">
+          <label className="block text-sm font-medium mb-1">Description</label>
+          {isEditing ? (
+            <textarea
+              className="textarea textarea-bordered w-full"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          ) : (
+            <p className="text-sm text-gray-300">{description || "No description"}</p>
+          )}
+          <div className="mt-2 flex justify-end gap-2">
+            {isEditing ? (
+              <>
+                <button className="btn btn-sm btn-primary" onClick={handleSave}>
+                  Save
+                </button>
+                <button
+                  className="btn btn-sm btn-ghost"
+                  onClick={() => setIsEditing(false)}
+                >
+                  Cancel
+                </button>
+              </>
+            ) : (
+              <button
+                className="btn btn-sm btn-outline"
+                onClick={() => setIsEditing(true)}
+              >
+                Edit
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Members */}
+        <div>
+          <label className="block text-sm font-medium mb-2 flex items-center gap-1">
+            <Users className="w-4 h-4" /> Members
+          </label>
+          <ul className="max-h-48 overflow-y-auto">
+            {group.members?.length > 0 ? (
+              group.members.map((member) => (
+                <li
+                  key={member._id || member}
+                  className="text-sm py-1 border-b border-base-300"
+                >
+                  {member.fullName || member.name || "Unknown"}
+                </li>
+              ))
+            ) : (
+              <p className="text-gray-400 text-sm">No members yet</p>
+            )}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GroupInfoPopup;


### PR DESCRIPTION
Solution of the issue #57 


This PR allows group admins to edit the group description directly from the group info popup and displays a list of all group members in the same popup, making it easier to manage and view group details.

<img width="1470" height="956" alt="Screenshot 2025-10-19 at 11 50 30 PM" src="https://github.com/user-attachments/assets/5e44bf2c-dddc-4cc8-99f3-f11c1e3ef80e" />

